### PR TITLE
fix: non-compound name GLPIKey

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -29,7 +29,6 @@
  */
 
 use GlpiPlugin\Centreon\Host;
-use GLPIKey;
 
 /**
  * Plugin install process


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes N/A

Prevent warning message on plugins page:

```
glpiphplog.WARNING:   *** PHP Warning (2): The use statement with non-compound name 'GLPIKey' has no effect in .../plugins/centreon/hook.php at line 32
  Backtrace :
  src/Plugin.php:2020                                include_once()
  src/Plugin.php:377                                 Plugin::includeHook()
  src/Plugin.php:2641                                Plugin::load()
  src/Search.php:7872                                Plugin::getSpecificValueToDisplay()
  src/Search.php:1734                                Search::giveItem()
  src/Search.php:451                                 Search::constructData()
  src/Search.php:202                                 Search::getDatas()
  src/Search.php:179                                 Search::showList()
  front/plugin.php:56                                Search::show()
  public/index.php:82                                require()
```

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/2865940e-f9f9-448f-8aad-f344f662cc41)

