### PR TITLE
Fix(install): use unsigned integers for primary and foreign key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [UNRELEASED]
+
+### Fixed
+
+- Fix installation warning about `signed integers is discouraged`

--- a/hook.php
+++ b/hook.php
@@ -43,13 +43,15 @@ function plugin_centreon_install($version)
     $default_charset   = DBConnection::getDefaultCharset();
     $default_collation = DBConnection::getDefaultCollation();
 
+    $migration = new Migration(PLUGIN_CENTREON_VERSION);
+
     $table = GlpiPlugin\Centreon\Host::getTable();
     if (!$DB->tableExists($table)) {
         $query = "CREATE TABLE `$table` (
                   `id`            INT UNSIGNED NOT NULL AUTO_INCREMENT,
                   `itemtype`      VARCHAR(100) NOT NULL,
-                  `items_id`      INT(10) UNSIGNED NOT NULL DEFAULT '0',
-                  `centreon_id`   INT(10) NOT NULL,
+                  `items_id`      INT UNSIGNED NOT NULL DEFAULT '0',
+                  `centreon_id`   INT UNSIGNED NOT NULL,
                   `centreon_type` VARCHAR(100) DEFAULT 'host',
                   PRIMARY KEY  (`id`),
                   KEY `items_id` (`items_id`)
@@ -57,6 +59,9 @@ function plugin_centreon_install($version)
                  DEFAULT CHARSET={$default_charset}
                  COLLATE={$default_collation}";
         $DB->doQuery($query);
+    } else {
+        $migration->changeField($table, 'items_id', 'items_id', "int unsigned NOT NULL DEFAULT '0'");
+        $migration->changeField($table, 'centreon_id', 'centreon_id', "int unsigned NOT NULL");
     }
     $centreon_password = Config::getConfigurationValue('plugin:centreon', 'centreon-password');
     /**Migration to 1.0.1 */


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description 

- It fixes #59 

During plugin installation, a PHP warning could occur due to the use of an incorrect SQL field type:

```shell
[2025-09-04 12:17:30] glpiphplog.WARNING:   *** PHP User Warning (512): Usage of signed integers in primary or foreign keys is discouraged, please use unsigned integers instead in `glpi_plugin_centreon_hosts`.`items_id`. in /home//DEV/GLPI/10bugfixes/src/DBmysql.php at line 2181
  Backtrace :
  src/DBmysql.php:2181                               trigger_error()
  src/DBmysql.php:386                                DBmysql->checkForDeprecatedTableOptions()
  plugins/centreon/hook.php:59                       DBmysql->doQuery()
  src/Plugin.php:955                                 plugin_centreon_install()
  front/plugin.form.php:51                           Plugin->install()
  public/index.php:82                                require()
```

The issue was caused by the use of a signed integer in a primary or foreign key, which is discouraged.

 A migration script has been added to automatically update the field type.


## Screenshots (if appropriate):
