### PR TITLE
Fix(Config): prevent undefined array key from first configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Prevent warnings for uninitialized fields during plugin first-time setup
 - Fix installation warning about `signed integers is discouraged`

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -54,8 +54,8 @@ class ApiClient
             'json' => [
                 'security' => [
                     'credentials' => [
-                        'login'    => $this->api_config['centreon-username'],
-                        'password' => (new GLPIKey())->decrypt($this->api_config['centreon-password']),
+                        'login'    => $this->api_config['centreon-username'] ?? '',
+                        'password' => (new GLPIKey())->decrypt($this->api_config['centreon-password'] ?? ''),
                     ],
                 ],
             ],
@@ -102,7 +102,7 @@ class ApiClient
     public function clientRequest(string $endpoint = '', array $params = [], string $method = 'GET')
     {
         $api_client = new Client([
-            'base_uri' => $this->api_config['centreon-url'],
+            'base_uri' => $this->api_config['centreon-url'] ?? '',
             'verify' => false,
             'connect_timeout' => 3,
             'timeout' => 10,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

When configuring the plugin for the first time, three warnings were displayed because no values existed yet for non-initialized fields:

<img width="1649" height="813" alt="image" src="https://github.com/user-attachments/assets/49167c31-56d1-4451-a5b8-c394d7183812" />  

This PR prevents these warnings from being triggered during the initial setup.


## Screenshots (if appropriate):
