### PR TITLE
prepare 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+## [1.0.3] - 2025-09-04
+
 ### Fixed
 
 - Prevent warnings for uninitialized fields during plugin first-time setup

--- a/centreon.xml
+++ b/centreon.xml
@@ -32,6 +32,11 @@
          <download_url>https://github.com/pluginsGLPI/centreon/releases/download/1.1.0-beta2/glpi-centreon-1.1.0-beta2.tar.bz2</download_url>
       </version>
       <version>
+         <num>1.0.3</num>
+            <compatibility>~10.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/centreon/releases/download/1.0.3/glpi-centreon-1.0.3.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.0.2</num>
             <compatibility>~10.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/centreon/releases/download/1.0.2/glpi-centreon-1.0.2.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_CENTREON_VERSION', '1.0.2');
+define('PLUGIN_CENTREON_VERSION', '1.0.3');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_CENTREON_MIN_GLPI_VERSION', '10.0.0');


### PR DESCRIPTION
## [1.0.3] - 2025-09-04

### Fixed

- Prevent warnings for uninitialized fields during plugin first-time setup
- Fix installation warning about `signed integers is discouraged`
