### PR TITLE
Compare case-insensitively Centreon host names & GLPI asset names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1] - 2025-10-02
+
+### Fixed
+
+- Host matching now works regardless of uppercase/lowercase in GLPI computer names
+
 ## [1.1.0] - 2025-09-29
 
 ### Added

--- a/src/Host.php
+++ b/src/Host.php
@@ -457,7 +457,7 @@ class Host extends CommonDBTM
                 'query' => [
                     'search' => json_encode([
                         'host.name' => [
-                            '$lk' => '%' . $computer_name . '%'
+                            '$lk' => '%' . $computer_name . '%',
                         ],
                     ]),
                 ],
@@ -476,7 +476,7 @@ class Host extends CommonDBTM
                     ]);
                     $this->getFromDB($new_id);
                 }
-             }
+            }
 
             return true;
 

--- a/src/Host.php
+++ b/src/Host.php
@@ -457,26 +457,31 @@ class Host extends CommonDBTM
                 'query' => [
                     'search' => json_encode([
                         'host.name' => [
-                            '$eq' => $computer_name,
+                            '$lk' => '%' . $computer_name . '%'
                         ],
                     ]),
                 ],
             ];
             $match = $api->getHostsList($params);
-        }
 
-        if (isset($match['result']['0']['name']) && $match['result']['0']['name'] == $computer_name) {
-            $centreon_id = $match['result']['0']['id'];
-            $new_id      = $this->add([
-                'itemtype'      => 'Computer',
-                'items_id'      => $id,
-                'centreon_id'   => $centreon_id,
-                'centreon_type' => 'host',
-            ]);
-            $this->getFromDB($new_id);
+            //compare results case-insensitively
+            foreach ($match['result'] as $host) {
+                if (strcasecmp($host['name'], $computer_name) === 0) {
+                    $centreon_id = $host['id'];
+                    $new_id = $this->add([
+                        'itemtype'      => 'Computer',
+                        'items_id'      => $id,
+                        'centreon_id'   => $centreon_id,
+                        'centreon_type' => 'host',
+                    ]);
+                    $this->getFromDB($new_id);
+                }
+             }
 
             return true;
+
         } else {
+
             return false;
         }
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39486
- Here is a brief description of what this PR does : 

This update fixes host matching between GLPI Computers and Centreon hosts. Matching now ignores letter casing, so computers named in uppercase or mixed case are correctly linked to their corresponding Centreon hosts.

## Screenshots (if appropriate):
